### PR TITLE
Update index.html (NASCIO reference, editorial)

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,7 @@
           <p>All relevant outcomes should be addressed but not all outcomes will apply to all organizations and situations. When an outcome does not apply, it is marked N/A (Not applicable). For example, an accessibility policy does not need to reference native applications if the organization has none.</p>
           <p>Stages are cumulative, so stage advancement is achieved by first meeting the specific criteria of a lower level.</p>
           <p>Note: The terms for the stages were adopted for consistency with the <a href="https://www.nascio.org/pdaa">Policy-Driven Adoption for Accessibility</a> maturity model, currently being used by some U.S. state and local government agencies.</p>
+            
           <p>Stages loosely correspond to the following criteria:</p>
           <table>
             <tr>

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
           <p>Each stage is attained by meeting the defined outcomes for that specific [=dimension=]. The completed [=proof points=] demonstrate the efforts to achieve the outcomes for a [=maturity stage=].</p>
           <p>All relevant outcomes should be addressed but not all outcomes will apply to all organizations and situations. When an outcome does not apply, it is marked N/A (Not applicable). For example, an accessibility policy does not need to reference native applications if the organization has none.</p>
           <p>Stages are cumulative, so stage advancement is achieved by first meeting the specific criteria of a lower level.</p>
-          <p>Note: The terms for the stages were adopted for consistency with the <a href="https://www.nascio.org/resource-center/?selectedTopic=accessibility">Policy Driven Adoption Maturity Model</a>, currently being used by some U.S. government agencies.</p>
+          <p>Note: The terms for the stages were adopted for consistency with the <a href="https://www.nascio.org/resource-center/?selectedTopic=accessibility">Policy Driven Adoption Maturity Model</a>, currently being used by some U.S. state and local government agencies.</p>
           <p>Stages loosely correspond to the following criteria:</p>
           <table>
             <tr>

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
           <p>Each stage is attained by meeting the defined outcomes for that specific [=dimension=]. The completed [=proof points=] demonstrate the efforts to achieve the outcomes for a [=maturity stage=].</p>
           <p>All relevant outcomes should be addressed but not all outcomes will apply to all organizations and situations. When an outcome does not apply, it is marked N/A (Not applicable). For example, an accessibility policy does not need to reference native applications if the organization has none.</p>
           <p>Stages are cumulative, so stage advancement is achieved by first meeting the specific criteria of a lower level.</p>
-          <p>Note: The terms for the stages were adopted for consistency with the <a href="https://www.nascio.org/resource-center/?selectedTopic=accessibility">Policy Driven Adoption Maturity Model</a>, currently being used by some U.S. state and local government agencies.</p>
+          <p>Note: The terms for the stages were adopted for consistency with the <a href="https://www.nascio.org/pdaa">Policy-Driven Adoption for Accessibility</a> maturity model, currently being used by some U.S. state and local government agencies.</p>
           <p>Stages loosely correspond to the following criteria:</p>
           <table>
             <tr>


### PR DESCRIPTION
<q>U.S. government agencies</q> implies U.S. federal government.  Reference cited is to NASCIO which is an organization supporting U.S. state and local government.  [NASCIO > about](https://www.nascio.org/about/mission-strategic-direction/)

Terms for [Maturity Levels](https://www.section508.gov/manage/reporting/questions/index.html#maturity-levels) stages currently being used by the U.S. federal government are significantly different.