### PR TITLE
Fixes #114

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,9 +371,9 @@
           <h4>Proof Points</h4>
           <p>Knowledge and skills proof points may include but are not limited to:</p>
           <section id="assess-knowledge-and-skills">
-            <h5>Assessing Current Skills to Identify and Address Gaps</h5>
+            <h5>Assessing Skills to Identify and Address Gaps</h5>
             <ul>
-              <li>Organizational surveys that identify current skill levels and gaps</li>
+              <li>Organizational surveys that identify skill levels and gaps</li>
               <li>Internal database(s) to track employee training for ICT accessibility skills</li> 
               <li>Certification or competency reviews and programs</li>
               <li>Keeping skills up-to-date with current requirements</li>


### PR DESCRIPTION
Wasn't sure if we wanted to remove "current" from both the heading and the content.  Removed from both places. Happy to adjust.