### PR TITLE
scope section removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,14 +244,6 @@
           and
           governance in place.</li>
       </ul>
-      <section id="scope">
-        <h4>Scope</h4>
-        <p>This framework encompasses the full scope of an organization's accessibility responsibilities. It brings the
-          power of web technologies to the task of identifying those responsibilities and establishing processes to
-          measure performance over time.</p>
-        <p>This framework may also be used to measure the accessibility maturity level of parts of the organization,
-          provided that the limited scope is clearly identified in any reports submitted to third parties.</p>
-      </section>
     </section>
   </section>
   <section id="maturity-model-structure">


### PR DESCRIPTION
Everything meaningful in the Scope section is already covered in the About section — the full organizational coverage, the subunit applicability, and the limited-scope reporting condition. - So we can remove scope section